### PR TITLE
Fix extension and handle namespaces and nested template declarations

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -2,8 +2,8 @@ const vscode = require('vscode');
 
 let conf = vscode.workspace.getConfiguration("definition-autocompletion");
 
-let header_file_regex = ".*("; + conf.get("header_file_extension_patterns").join("$|") + "$)";
-let source_file_regex = ".*("; + conf.get("source_file_extension_patterns").join("$|") + "$)";
+let header_file_regex = ".*(" + conf.get("header_file_extension_patterns").join("|") + ")";
+let source_file_regex = ".*(" + conf.get("source_file_extension_patterns").join("|") + ")";
 
 var file_pairs = new Object();
 
@@ -117,7 +117,7 @@ class FilePairFactory {
 						if (header_uri_array.length) {
 							header_uri = header_uri_array[0];
 						}
-						new FileFinder().match_base().match_file_name(file_name).match_extensions(conf.get("header_file_extension_patterns")).find_files().then(
+						new FileFinder().match_base().match_file_name(file_name).match_extensions(conf.get("source_file_extension_patterns")).find_files().then(
 							function (source_uri_array) {
 								if (source_uri_array.length) {
 									source_uri = source_uri_array[0];


### PR DESCRIPTION
- The last commit of the extension (after the addition of the config option to define header/source file extension patterns) was broken. This PR fixes it (fixes #2 )
- Now namespaces are handled and prepended to method signatures
- Nested template declarations now work as well (fixes #4 )
- Remove default template arguments' value in definition

This:
```
namespace N
{

template <class T, class U, class V, std::size_t Dim, class X>
class Test
{
public:
    template <class S, std::size_t SDim = 2>
    class Me
    {
    public:
        template <class U = 1>
        void testMe(U const &val) const;  
    };
};

} // namespace N
```

Produces:
```
template <class T, class U, class V, std::size_t Dim, class X>
template <class S, std::size_t SDim>
template <class U>
void N::Test<T, U, V, Dim, X>::Me<S, SDim>::testMe(U const &val) const {
    
}
```